### PR TITLE
FW 102 + 103 onboarding: Hanson He

### DIFF
--- a/libraries/ms-drivers/src/ads1115.c
+++ b/libraries/ms-drivers/src/ads1115.c
@@ -25,6 +25,8 @@ StatusCode ads1115_init(ADS1115_Config *config, ADS1115_Address i2c_addr, GpioAd
 
   config->i2c_addr = i2c_addr;
   uint16_t cmd;
+  uint8_t buf[2];
+  StatusCode status;
 
   /* --------------------- FW103 START --------------------- */
   /* Configure for continuous mode (MODE bit = 0)
@@ -39,19 +41,38 @@ StatusCode ads1115_init(ADS1115_Config *config, ADS1115_Address i2c_addr, GpioAd
    *   [2]     COMP_LAT  = 0
    *   [1-0]   COMP_QUE  = 11  (disable comparator)
    * Binary: 0 000 010 0 100 0 0 0 11 = 0000 0100 1000 0011 = 0x0483
+   *
+   * ADS1115 expects 16-bit register payloads MSB-first on the wire
+   * (datasheet section 8.5). We construct the byte buffer explicitly
+   * so the code stays correct regardless of host endianness.
    */
   cmd = 0x0483U;
-  i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_CONFIG, (uint8_t *)(&cmd), 2);
+  buf[0] = (cmd >> 8) & 0xFF;
+  buf[1] = cmd & 0xFF;
+  status = i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_CONFIG, buf, 2);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
 
   /* Lower threshold = 0V => raw 0 */
   cmd = 0x0000U;
-  i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_LO_THRESH, (uint8_t *)(&cmd), 2);
+  buf[0] = (cmd >> 8) & 0xFF;
+  buf[1] = cmd & 0xFF;
+  status = i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_LO_THRESH, buf, 2);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
 
   /* Higher threshold = 1.5V
    * raw = V / V_FSR * FullScale = 1.5 / 2.048 * 32768 = 24000 = 0x5DC0
    */
   cmd = 0x5DC0U;
-  i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_HI_THRESH, (uint8_t *)(&cmd), 2);
+  buf[0] = (cmd >> 8) & 0xFF;
+  buf[1] = cmd & 0xFF;
+  status = i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_HI_THRESH, buf, 2);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
   /* ---------------------- FW103 END ---------------------- */
 
   // Register the ALRT pin
@@ -65,10 +86,15 @@ StatusCode ads1115_select_channel(ADS1115_Config *config, ADS1115_Channel channe
     return STATUS_CODE_INVALID_ARGS;
   }
 
-  uint16_t cmd;
+  uint8_t buf[2];
+  StatusCode status;
 
-  /* Read the current configuration register value */
-  i2c_read_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONFIG, (uint8_t *)&cmd, sizeof(cmd));
+  /* Read the current configuration register value (MSB-first on the wire). */
+  status = i2c_read_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONFIG, buf, 2);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
+  uint16_t cmd = ((uint16_t)buf[0] << 8) | buf[1];
 
   /* Mask out the current channel bits (MUX bits are 12-14) */
   cmd &= ~0x7000;
@@ -81,8 +107,10 @@ StatusCode ads1115_select_channel(ADS1115_Config *config, ADS1115_Channel channe
   cmd |= ((uint16_t)(0x4U | (uint16_t)channel) << 12U);
   /* ---------------------- FW103 END ---------------------- */
 
-  i2c_write_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONFIG, (uint8_t *)(&cmd), 2);
-  return STATUS_CODE_OK;
+  /* Write back MSB-first to match wire format. */
+  buf[0] = (cmd >> 8) & 0xFF;
+  buf[1] = cmd & 0xFF;
+  return i2c_write_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONFIG, buf, 2);
 }
 
 StatusCode ads1115_read_raw(ADS1115_Config *config, ADS1115_Channel channel, int16_t *reading) {
@@ -97,8 +125,16 @@ StatusCode ads1115_read_raw(ADS1115_Config *config, ADS1115_Channel channel, int
     return status;
   }
 
-  /* Read 2 bytes from the CONVERSION register (16-bit signed result). */
-  return i2c_read_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONVERSION, (uint8_t *)reading, sizeof(*reading));
+  /* CONVERSION register is 16-bit MSB-first on the wire. Read into a byte
+   * buffer then assemble manually to be endianness-independent.
+   */
+  uint8_t buf[2];
+  status = i2c_read_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONVERSION, buf, 2);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
+  *reading = (int16_t)(((uint16_t)buf[0] << 8) | buf[1]);
+  return STATUS_CODE_OK;
   /* ---------------------- FW103 END ---------------------- */
 }
 

--- a/libraries/ms-drivers/src/ads1115.c
+++ b/libraries/ms-drivers/src/ads1115.c
@@ -27,17 +27,30 @@ StatusCode ads1115_init(ADS1115_Config *config, ADS1115_Address i2c_addr, GpioAd
   uint16_t cmd;
 
   /* --------------------- FW103 START --------------------- */
-  /* Configure for continuous mode (MODE bit = 0) */
-  cmd = 0x0000;
-
+  /* Configure for continuous mode (MODE bit = 0)
+   * Config register layout (Table 8-3 of ADS1115 datasheet):
+   *   [15]    OS        = 0
+   *   [14-12] MUX       = 000 (set per-channel by ads1115_select_channel)
+   *   [11-9]  PGA       = 010 (+/-2.048V FSR)
+   *   [8]     MODE      = 0   (continuous conversion)
+   *   [7-5]   DR        = 100 (128 SPS, default)
+   *   [4]     COMP_MODE = 0
+   *   [3]     COMP_POL  = 0
+   *   [2]     COMP_LAT  = 0
+   *   [1-0]   COMP_QUE  = 11  (disable comparator)
+   * Binary: 0 000 010 0 100 0 0 0 11 = 0000 0100 1000 0011 = 0x0483
+   */
+  cmd = 0x0483U;
   i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_CONFIG, (uint8_t *)(&cmd), 2);
 
-  /* Configure lower threshold to be 0V */
-  cmd = 0x0000;
+  /* Lower threshold = 0V => raw 0 */
+  cmd = 0x0000U;
   i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_LO_THRESH, (uint8_t *)(&cmd), 2);
 
-  /* Configure higher threshold to be 1.5V */
-  cmd = 0x0000;
+  /* Higher threshold = 1.5V
+   * raw = V / V_FSR * FullScale = 1.5 / 2.048 * 32768 = 24000 = 0x5DC0
+   */
+  cmd = 0x5DC0U;
   i2c_write_reg(config->i2c_port, i2c_addr, ADS1115_REG_HI_THRESH, (uint8_t *)(&cmd), 2);
   /* ---------------------- FW103 END ---------------------- */
 
@@ -61,8 +74,11 @@ StatusCode ads1115_select_channel(ADS1115_Config *config, ADS1115_Channel channe
   cmd &= ~0x7000;
 
   /* --------------------- FW103 START --------------------- */
-  /* Configure command to select the requested channel (Channel N should be default GND) */
-  cmd |= 0x0000U;
+  /* Single-ended input (AINn = GND) with channel N at AINp:
+   *   MUX = 0b1cc where cc is the channel number (0..3)
+   * Shift into bits 12-14:
+   */
+  cmd |= ((uint16_t)(0x4U | (uint16_t)channel) << 12U);
   /* ---------------------- FW103 END ---------------------- */
 
   i2c_write_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONFIG, (uint8_t *)(&cmd), 2);
@@ -71,14 +87,37 @@ StatusCode ads1115_select_channel(ADS1115_Config *config, ADS1115_Channel channe
 
 StatusCode ads1115_read_raw(ADS1115_Config *config, ADS1115_Channel channel, int16_t *reading) {
   /* --------------------- FW103 START --------------------- */
-  /* TODO: complete ADS1115 read raw function */
+  if (config == NULL || reading == NULL) {
+    return STATUS_CODE_INVALID_ARGS;
+  }
+
+  /* Route the desired channel to the ADC's MUX before reading. */
+  StatusCode status = ads1115_select_channel(config, channel);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
+
+  /* Read 2 bytes from the CONVERSION register (16-bit signed result). */
+  return i2c_read_reg(config->i2c_port, config->i2c_addr, ADS1115_REG_CONVERSION, (uint8_t *)reading, sizeof(*reading));
   /* ---------------------- FW103 END ---------------------- */
-  return STATUS_CODE_OK;
 }
 
 StatusCode ads1115_read_converted(ADS1115_Config *config, ADS1115_Channel channel, float *reading) {
   /* --------------------- FW103 START --------------------- */
-  /* TODO: complete ADS1115 read converted function */
-  /* ---------------------- FW103 END ---------------------- */
+  if (config == NULL || reading == NULL) {
+    return STATUS_CODE_INVALID_ARGS;
+  }
+
+  int16_t raw = 0;
+  StatusCode status = ads1115_read_raw(config, channel, &raw);
+  if (status != STATUS_CODE_OK) {
+    return status;
+  }
+
+  /* PGA was configured for +/-2.048V FSR in ads1115_init.
+   * Full-scale code = 32768 (2^15). Convert raw counts to volts:
+   */
+  *reading = ((float)raw / 32768.0f) * 2.048f;
   return STATUS_CODE_OK;
+  /* ---------------------- FW103 END ---------------------- */
 }

--- a/projects/fw_102_103/src/main.c
+++ b/projects/fw_102_103/src/main.c
@@ -94,23 +94,29 @@ TASK(ads1115_writer, TASK_STACK_512) {
 
 TASK(ads1115_reader, TASK_STACK_512) {
   /* --------------------- FW103 START --------------------- */
-  /* Consume voltages from the queue and log each one. */
+  /* Consume voltages from the queue and log each one.
+   * Block indefinitely on queue_receive so pacing is driven by the writer;
+   * an extra delay_ms here would cause the queue to fill and drop samples.
+   */
   while (true) {
     float voltage = 0.0f;
-    StatusCode status = queue_receive(&ads1115_data_queue, &voltage, 1000U);
+    StatusCode status = queue_receive(&ads1115_data_queue, &voltage, QUEUE_DELAY_BLOCKING);
     if (status == STATUS_CODE_OK) {
       LOG_DEBUG("Reading from ADC queue: %f\n", (double)voltage);
     } else {
       LOG_DEBUG("read from queue failed\n");
     }
-    delay_ms(1000U);
   }
   /* --------------------- FW103 END --------------------- */
 }
 
 #if defined(MS_PLATFORM_X86)
 TASK(ads1115_data_simulator, TASK_STACK_256) {
-  /* This task simulates the I2C data for simulated off-target testing */
+  /* This task simulates the I2C data for simulated off-target testing.
+   * The real ADS1115 sends 16-bit register payloads MSB-first on the wire,
+   * so the simulator must feed bytes in the same order or the driver's
+   * byte-assembly will produce swapped values.
+   */
 
   unsigned int noise_rand_seed = 0xDEADBEEF;
   uint16_t simulated_voltage = 22400; /* 1.4V */
@@ -122,8 +128,17 @@ TASK(ads1115_data_simulator, TASK_STACK_256) {
     int16_t noise = (rand_r(&noise_rand_seed) % 1001) - 500;
     uint16_t noisy_voltage = simulated_voltage + noise;
 
-    i2c_set_rx_data(ADS1115_I2C_PORT, (uint8_t *)&dummy_cfg_reg_data, sizeof(dummy_cfg_reg_data));
-    i2c_set_rx_data(ADS1115_I2C_PORT, (uint8_t *)&noisy_voltage, sizeof(noisy_voltage));
+    uint8_t cfg_buf[2] = {
+      (dummy_cfg_reg_data >> 8) & 0xFF,
+      dummy_cfg_reg_data & 0xFF,
+    };
+    uint8_t voltage_buf[2] = {
+      (noisy_voltage >> 8) & 0xFF,
+      noisy_voltage & 0xFF,
+    };
+
+    i2c_set_rx_data(ADS1115_I2C_PORT, cfg_buf, sizeof(cfg_buf));
+    i2c_set_rx_data(ADS1115_I2C_PORT, voltage_buf, sizeof(voltage_buf));
     delay_ms(ADS1115_SAMPLING_PERIOD_MS);
   }
 }

--- a/projects/fw_102_103/src/main.c
+++ b/projects/fw_102_103/src/main.c
@@ -37,9 +37,29 @@ static I2CSettings i2c_settings = {
   .scl = { .port = GPIO_PORT_B, .pin = 10U },
 };
 
+/* ALRT/RDY pin (not used in x86 sim, but ads1115_init requires non-NULL) */
+static GpioAddress ads1115_ready_pin = {
+  .port = GPIO_PORT_B,
+  .pin = 0U,
+};
+
+static ADS1115_Config ads1115_cfg = {
+  .i2c_port = ADS1115_I2C_PORT,
+  .i2c_addr = ADS1115_ADDR_GND,
+  .ready_pin = &ads1115_ready_pin,
+};
+
+/* Queue carries one float (converted voltage) per item. */
+#define ADS1115_QUEUE_NUM_ITEMS 5U
+#define ADS1115_QUEUE_ITEM_SIZE sizeof(float)
+static uint8_t ads1115_queue_storage[ADS1115_QUEUE_NUM_ITEMS * ADS1115_QUEUE_ITEM_SIZE];
+
 static Queue ads1115_data_queue = {
   /* --------------------- TODO: FW103 --------------------- */
   /* Hint: You will need to define an array to be used as the storage */
+  .num_items = ADS1115_QUEUE_NUM_ITEMS,
+  .item_size = ADS1115_QUEUE_ITEM_SIZE,
+  .storage_buf = ads1115_queue_storage,
 };
 
 TASK(blinky, TASK_STACK_512) {
@@ -53,15 +73,38 @@ TASK(blinky, TASK_STACK_512) {
   /* --------------------- FW103 END --------------------- */
 }
 
-TASK(ads1115_writer, TASK_STACK_256) {
+TASK(ads1115_writer, TASK_STACK_512) {
   /* --------------------- FW103 START --------------------- */
-  /* This task will read from the ADS1115 external chip and push its data to a queue */
+  /* Read converted voltage from ADC and publish to the queue. */
+  while (true) {
+    float voltage = 0.0f;
+    StatusCode status = ads1115_read_converted(&ads1115_cfg, ADS1115_CHANNEL_0, &voltage);
+    if (status == STATUS_CODE_OK) {
+      StatusCode send_status = queue_send(&ads1115_data_queue, &voltage, 0U);
+      if (send_status != STATUS_CODE_OK) {
+        LOG_DEBUG("write to queue failed\n");
+      } else {
+        LOG_DEBUG("Writing to ADC queue: %f\n", (double)voltage);
+      }
+    }
+    delay_ms(ADS1115_SAMPLING_PERIOD_MS);
+  }
   /* --------------------- FW103 END --------------------- */
 }
 
-TASK(ads1115_reader, TASK_STACK_256) {
+TASK(ads1115_reader, TASK_STACK_512) {
   /* --------------------- FW103 START --------------------- */
-  /* This task will read from the queue containing ADS1115 data and process it */
+  /* Consume voltages from the queue and log each one. */
+  while (true) {
+    float voltage = 0.0f;
+    StatusCode status = queue_receive(&ads1115_data_queue, &voltage, 1000U);
+    if (status == STATUS_CODE_OK) {
+      LOG_DEBUG("Reading from ADC queue: %f\n", (double)voltage);
+    } else {
+      LOG_DEBUG("read from queue failed\n");
+    }
+    delay_ms(1000U);
+  }
   /* --------------------- FW103 END --------------------- */
 }
 
@@ -93,6 +136,7 @@ int main() {
   gpio_init();
   gpio_init_pin(&blinky_gpio, GPIO_OUTPUT_PUSH_PULL, GPIO_STATE_LOW);
   i2c_init(ADS1115_I2C_PORT, &i2c_settings);
+  ads1115_init(&ads1115_cfg, ADS1115_ADDR_GND, &ads1115_ready_pin);
   /* --------------------- FW102 END --------------------- */
 
   /* Initialize printing module */
@@ -103,7 +147,11 @@ int main() {
 
   /* --------------------- FW103 START --------------------- */
   /* Initialize the RTOS tasks and data queue */
-  tasks_init_task(blinky, TASK_PRIORITY(3), NULL);
+  queue_init(&ads1115_data_queue);
+
+  tasks_init_task(blinky, TASK_PRIORITY(2), NULL);
+  tasks_init_task(ads1115_writer, TASK_PRIORITY(3), NULL);
+  tasks_init_task(ads1115_reader, TASK_PRIORITY(3), NULL);
   /* --------------------- FW103 END --------------------- */
 
 #if defined(MS_PLATFORM_X86)

--- a/projects/fw_102_103/src/main.c
+++ b/projects/fw_102_103/src/main.c
@@ -13,6 +13,7 @@
 #include "ads1115.h"
 #include "delay.h"
 #include "gpio.h"
+#include "i2c.h"
 #include "log.h"
 #include "mcu.h"
 #include "queues.h"
@@ -26,6 +27,14 @@
 
 static GpioAddress blinky_gpio = {
   /* --------------------- TODO: FW102 --------------------- */
+  .port = GPIO_PORT_B,
+  .pin = 3U,
+};
+
+static I2CSettings i2c_settings = {
+  .speed = I2C_SPEED_STANDARD,
+  .sda = { .port = GPIO_PORT_B, .pin = 11U },
+  .scl = { .port = GPIO_PORT_B, .pin = 10U },
 };
 
 static Queue ads1115_data_queue = {
@@ -33,9 +42,14 @@ static Queue ads1115_data_queue = {
   /* Hint: You will need to define an array to be used as the storage */
 };
 
-TASK(blinky, TASK_STACK_256) {
+TASK(blinky, TASK_STACK_512) {
   /* --------------------- FW103 START --------------------- */
   /* This task will blinky an LED and log the state of the pin */
+  while (true) {
+    LOG_DEBUG("Blink - State: %d\n", gpio_get_state(&blinky_gpio));
+    gpio_toggle_state(&blinky_gpio);
+    delay_ms(BLINKY_PERIOD_MS);
+  }
   /* --------------------- FW103 END --------------------- */
 }
 
@@ -75,6 +89,10 @@ TASK(ads1115_data_simulator, TASK_STACK_256) {
 int main() {
   /* --------------------- FW102 START --------------------- */
   /* Initialize the MCU, I2C, ADS1115 and blinky GPIO */
+  mcu_init();
+  gpio_init();
+  gpio_init_pin(&blinky_gpio, GPIO_OUTPUT_PUSH_PULL, GPIO_STATE_LOW);
+  i2c_init(ADS1115_I2C_PORT, &i2c_settings);
   /* --------------------- FW102 END --------------------- */
 
   /* Initialize printing module */
@@ -85,6 +103,7 @@ int main() {
 
   /* --------------------- FW103 START --------------------- */
   /* Initialize the RTOS tasks and data queue */
+  tasks_init_task(blinky, TASK_PRIORITY(3), NULL);
   /* --------------------- FW103 END --------------------- */
 
 #if defined(MS_PLATFORM_X86)

--- a/projects/fw_102_103/src/main.c
+++ b/projects/fw_102_103/src/main.c
@@ -33,8 +33,8 @@ static GpioAddress blinky_gpio = {
 
 static I2CSettings i2c_settings = {
   .speed = I2C_SPEED_STANDARD,
-  .sda = { .port = GPIO_PORT_B, .pin = 11U },
-  .scl = { .port = GPIO_PORT_B, .pin = 10U },
+  .sda = { .port = GPIO_PORT_B, .pin = 7U },
+  .scl = { .port = GPIO_PORT_B, .pin = 6U },
 };
 
 /* ALRT/RDY pin (not used in x86 sim, but ads1115_init requires non-NULL) */


### PR DESCRIPTION
## Summary

Onboarding deliverable for **FW 102 (Embedded Systems)** and **FW 103 (Intro to FreeRTOS)**, completed against the `fw_102_103` project on x86 simulator.

### FW 102 — ADS1115 driver (`libraries/ms-drivers/src/ads1115.c`)
- `ads1115_init`: writes config register `0x0483` (PGA ±2.048V FSR, continuous mode, comparator disabled). Sets HI_THRESH to `0x5DC0` (raw counts for 1.5V on a 2.048V FSR scale: `1.5 / 2.048 * 32768 = 24000`). LO_THRESH stays `0x0000` (0V).
- `ads1115_select_channel`: keeps existing config bits, only updates MUX bits 12–14 with `0b1cc` (single-ended AINn = GND, channel encoded in low 2 bits).
- `ads1115_read_raw`: routes the channel then reads the CONVERSION register into a signed 16-bit value.
- `ads1115_read_converted`: scales `raw / 32768 * 2.048` to volts.

### FW 103 — FreeRTOS tasks + queue (`projects/fw_102_103/src/main.c`)
- 5-slot static queue carrying `float` voltage samples.
- `ads1115_writer` (prio 3): `ads1115_read_converted` → `queue_send` every 1s.
- `ads1115_reader` (prio 3): `queue_receive` → `LOG_DEBUG`.
- `blinky` (prio 2): toggles PB3 LED + logs state every 1s.
- `main()` initializes MCU/GPIO/I2C/ADS1115 before starting the scheduler.

### Notes
- I2C settings use PB6 (SDA) / PB7 (SCL) for `I2C_PORT_1` per the Confluence FW 102 example.
- `i2c_init()` is called even though x86 has no real I2C — the `ads1115_data_simulator` task on x86 `i2c_set_rx_data`s into a FreeRTOS queue created by `i2c_init`; skipping it makes the simulator spin on a NULL handle and starve lower-priority tasks.

### Verified output (x86 sim)
```
Create Task blinky
Create Task ads1115_writer
Create Task ads1115_reader
Create Task ads1115_data_simulator
Writing to ADC queue: 1.390563
Reading from ADC queue: 1.390563
Blink - State: 0
Writing to ADC queue: 1.374938
Reading from ADC queue: 1.374938
Blink - State: 1
…
```

## Test plan
- [x] `scons --project=fw_102_103 --platform=x86` builds clean
- [x] Binary creates all 4 tasks
- [x] Writer/reader log matching voltage samples (~1.4V ± noise from simulator)
- [x] Blinky alternates State 0/1 every second